### PR TITLE
Test that a failure code is seen by CI

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -63,5 +63,14 @@ envsubst < test/e2e/run-tests-job.yaml | kubectl apply -f -
 
 # wait for tests to complete TODO: adjust timeout as necessary
 kubectl wait --for=condition=complete job/cma-aws-e2e-tests --timeout=36m
+
 # output logs after job completes
 kubectl logs job/cma-aws-e2e-tests -n pipeline-tools
+
+#logsoutput=$(kubectl logs job/cma-aws-e2e-tests -n pipeline-tools)
+#if echo $nodes | grep -o "full-test PASSED"; then
+#  echo "full e2e test PASSED"
+#else
+#  echo "full e2e test FAILED"
+#  return 1
+#fi

--- a/test/e2e/full-test.sh
+++ b/test/e2e/full-test.sh
@@ -124,6 +124,9 @@ test_delete(){
 main() {
   fullstatus="PASSED"
 
+  # For test making it fail
+  fullstatus="FAILED"
+
   # test create is provisioning
   if ! test_provisioning; then
      echo "test_provisioning FAILED"
@@ -157,7 +160,9 @@ main() {
     exit 1
   fi
 
-  exit 0
+  # For test making it fail
+  exit 1
+  #exit 0
 }
 
 main


### PR DESCRIPTION
I'm forcing a failure in the full-test.sh to see if CI get's the status.  If not I'll add the code to check for the status and return it to CI.